### PR TITLE
Implement plans page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import services from "./services";
 import msadmins from "./components/msadmins";
 import organizations from "./components/organizations";
 import applications from "./components/applications";
+import plans from "./components/plans";
 import settings from "./components/settings";
 import theme from "./theme";
 
@@ -14,6 +15,7 @@ function App() {
       <Resource name="Admins" {...msadmins} />
       <Resource name="Organizations" {...organizations} />
       <Resource name="Applications" {...applications} />
+      <Resource name="Plans" {...plans} />
       <Resource name="Settings" {...settings} />
     </Admin>
   );

--- a/src/components/msadmins/AdminCreate.js
+++ b/src/components/msadmins/AdminCreate.js
@@ -6,11 +6,8 @@ import {
   PasswordInput,
   required,
 } from "react-admin";
-import { parse } from "querystring";
 
 const AdminCreate = (props) => {
-  const data = parse(props.location.search);
-  console.log("AdminCreate", data);
   return (
     <Create label="Create" title="Create an Admin" {...props}>
       <SimpleForm redirect="show">

--- a/src/components/msadmins/AdminList.js
+++ b/src/components/msadmins/AdminList.js
@@ -1,12 +1,33 @@
 import React from "react";
 import { useMediaQuery } from "@material-ui/core";
-import { List, Datagrid, TextField, EmailField, SimpleList } from "react-admin";
+import {
+  List,
+  Datagrid,
+  TextField,
+  EmailField,
+  SimpleList,
+  TopToolbar,
+  ExportButton,
+  CreateButton,
+} from "react-admin";
+
+const AdminListActions = ({ basePath, data, resource }) => (
+  <TopToolbar>
+    <CreateButton basePath={basePath} />
+    <ExportButton basePath={basePath} record={data} resource={resource} />
+  </TopToolbar>
+);
 
 const AdminList = (props) => {
   const isSmall = useMediaQuery((theme) => theme.breakpoints.down("sm"));
 
   return (
-    <List label="Admins" title="Admins" {...props}>
+    <List
+      label="Admins"
+      title="Admins"
+      actions={<AdminListActions />}
+      {...props}
+    >
       {isSmall ? (
         <SimpleList
           linkType="show"

--- a/src/components/organizations/OrganizationShow.js
+++ b/src/components/organizations/OrganizationShow.js
@@ -30,8 +30,8 @@ const OrganizationShow = (props) => {
     <Show label="Show" actions={<OrganizationShowActions />} {...props}>
       <TabbedShowLayout>
         <Tab label="details">
+          <TextField label="Organization Name" source="organizationName" />
           <TextField label="ID" source="organizationId" />
-          <TextField source="organizationName" />
         </Tab>
         <Tab label="applications">
           <ReferenceManyField

--- a/src/components/plans/PlanCreate.js
+++ b/src/components/plans/PlanCreate.js
@@ -1,0 +1,51 @@
+import React from "react";
+import {
+  Create,
+  SimpleForm,
+  TextInput,
+  BooleanInput,
+  SelectInput,
+  NumberInput,
+  required,
+} from "react-admin";
+
+const PlanCreate = (props) => {
+  return (
+    <Create label="Create" title="Create a Plan" {...props}>
+      <SimpleForm redirect="show">
+        <TextInput label="Name" source="name" validate={[required()]} />
+        <BooleanInput
+          label="Logging"
+          source="logging"
+          validate={[required()]}
+        />
+        <NumberInput
+          label="Maximum Log Retention Period (Days)"
+          source="maxLogRetentionPeriod"
+          validate={[required()]}
+        />
+        <SelectInput
+          source="periodWeight"
+          validate={[required()]}
+          choices={[
+            { id: 1, name: "Monthly" },
+            { id: 3, name: "Quarterly" },
+            { id: 12, name: "Yearly" },
+          ]}
+        />
+        <NumberInput
+          label="Maximum requests per day"
+          source="maxRequestPerDay"
+          validate={[required()]}
+        />
+        <NumberInput
+          label="Maximum requests per minute"
+          source="maxRequestPerMin"
+          validate={[required()]}
+        />
+      </SimpleForm>
+    </Create>
+  );
+};
+
+export default PlanCreate;

--- a/src/components/plans/PlanCreate.js
+++ b/src/components/plans/PlanCreate.js
@@ -14,15 +14,10 @@ const PlanCreate = (props) => {
     <Create label="Create" title="Create a Plan" {...props}>
       <SimpleForm redirect="show">
         <TextInput label="Name" source="name" validate={[required()]} />
-        <BooleanInput
-          label="Logging"
-          source="logging"
-          validate={[required()]}
-        />
+        <BooleanInput label="Logging" source="logging" />
         <NumberInput
           label="Maximum Log Retention Period (Days)"
           source="maxLogRetentionPeriod"
-          validate={[required()]}
         />
         <SelectInput
           source="periodWeight"
@@ -36,12 +31,10 @@ const PlanCreate = (props) => {
         <NumberInput
           label="Maximum requests per day"
           source="maxRequestPerDay"
-          validate={[required()]}
         />
         <NumberInput
           label="Maximum requests per minute"
           source="maxRequestPerMin"
-          validate={[required()]}
         />
       </SimpleForm>
     </Create>

--- a/src/components/plans/PlanList.js
+++ b/src/components/plans/PlanList.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { useMediaQuery } from "@material-ui/core";
+import {
+  List,
+  Datagrid,
+  TextField,
+  SimpleList,
+  TopToolbar,
+  CreateButton,
+  ExportButton,
+} from "react-admin";
+
+const PlanListActions = ({ basePath, data, resource }) => (
+  <TopToolbar>
+    <CreateButton basePath={basePath} />
+    <ExportButton basePath={basePath} record={data} resource={resource} />
+  </TopToolbar>
+);
+
+const PlanList = (props) => {
+  const isSmall = useMediaQuery((theme) => theme.breakpoints.down("sm"));
+
+  return (
+    <List
+      label="Plans"
+      title="Plans"
+      actions={<PlanListActions />}
+      pagination={null}
+      {...props}
+    >
+      {isSmall ? (
+        <SimpleList linkType="show" primaryText={(record) => record.planName} />
+      ) : (
+        <Datagrid rowClick="show">
+          <TextField label="Name" source="planName" />
+          <TextField label="ID" source="id" />
+        </Datagrid>
+      )}
+    </List>
+  );
+};
+
+export default PlanList;

--- a/src/components/plans/PlanShow.js
+++ b/src/components/plans/PlanShow.js
@@ -1,0 +1,53 @@
+import React from "react";
+import {
+  Show,
+  TabbedShowLayout,
+  Tab,
+  TextField,
+  BooleanField,
+  TopToolbar,
+  DeleteButton,
+} from "react-admin";
+
+const PlanShowActions = ({ basePath, data, resource }) => (
+  <TopToolbar>
+    <DeleteButton basePath={basePath} record={data} resource={resource} />
+  </TopToolbar>
+);
+
+const PlanShow = (props) => {
+  return (
+    <Show label="Show" title="" actions={<PlanShowActions />} {...props}>
+      <TabbedShowLayout>
+        <Tab label="details">
+          <TextField label="Name" source="planName" />
+          <TextField label="ID" source="id" />
+        </Tab>
+        <Tab label="logging">
+          <BooleanField
+            source="logging"
+            valueLabelTrue="Logging has been enabled."
+            valueLabelFalse="Logging is not enabled."
+          />
+          <TextField
+            label="Maximum log retention period"
+            source="maxLogRetentionPeriod"
+          />
+          <TextField label="Period weight" source="periodWeight" />
+        </Tab>
+        <Tab label="requests">
+          <TextField
+            label="Maximum requests per day"
+            source="maxRequestPerDay"
+          />
+          <TextField
+            label="Maximum requests per minute"
+            source="maxRequestPerMin"
+          />
+        </Tab>
+      </TabbedShowLayout>
+    </Show>
+  );
+};
+
+export default PlanShow;

--- a/src/components/plans/index.js
+++ b/src/components/plans/index.js
@@ -1,0 +1,11 @@
+import PlanCreate from "./PlanCreate";
+import PlanList from "./PlanList";
+import PlanShow from "./PlanShow";
+import PlanIcon from "@material-ui/icons/Receipt";
+
+export default {
+  create: PlanCreate,
+  list: PlanList,
+  show: PlanShow,
+  icon: PlanIcon,
+};

--- a/src/hooks/useAdminProvider/index.js
+++ b/src/hooks/useAdminProvider/index.js
@@ -6,11 +6,7 @@ export default () => {
   const dataProvider = useDataProvider();
 
   useEffect(() => {
-    const fetchAdminList = async () => {
-      const { total } = await dataProvider.getList("Admins");
-      setAdminCount(total);
-    };
-    fetchAdminList();
+    dataProvider.getList("Admins").then(({ total }) => setAdminCount(total));
   }, [adminCount, dataProvider]);
 
   return [adminCount];

--- a/src/hooks/useApplicationProvider/index.js
+++ b/src/hooks/useApplicationProvider/index.js
@@ -6,11 +6,9 @@ export default () => {
   const dataProvider = useDataProvider();
 
   useEffect(() => {
-    const fetchAppList = async () => {
-      const { total } = await dataProvider.getList("Applications");
-      setApplicationCount(total);
-    };
-    fetchAppList();
+    dataProvider
+      .getList("Applications")
+      .then(({ total }) => setApplicationCount(total));
   }, [applicationCount, dataProvider]);
 
   return [applicationCount];

--- a/src/hooks/useOrganizationProvider/index.js
+++ b/src/hooks/useOrganizationProvider/index.js
@@ -6,11 +6,9 @@ export default () => {
   const dataProvider = useDataProvider();
 
   useEffect(() => {
-    const fetchOrgList = async () => {
-      const { total } = await dataProvider.getList("Organizations");
-      setOrganizationCount(total);
-    };
-    fetchOrgList();
+    dataProvider
+      .getList("Organizations")
+      .then(({ total }) => setOrganizationCount(total));
   }, [organizationCount, dataProvider]);
 
   return [organizationCount];

--- a/src/services/data-provider.js
+++ b/src/services/data-provider.js
@@ -29,7 +29,9 @@ export default {
     return httpClient(`${endpoint.url}?${stringify(query)}`).then(
       ({ json }) => ({
         data: endpoint.getData(json.data),
-        total: json.data.pageInfo.totalRecord,
+        total: json.data.pageInfo
+          ? json.data.pageInfo.totalRecord
+          : json.data.length,
       })
     );
   },

--- a/src/services/data-provider.js
+++ b/src/services/data-provider.js
@@ -38,24 +38,30 @@ export default {
 
   getOne: (resource, params) => {
     const endpoint = endpoints(GET_ONE, resource, params);
-    return httpClient(endpoint.url).then(({ json }) => ({
-      data: endpoint.getData(json.data),
-    }));
+    return httpClient(endpoint.url)
+      .then(({ json }) => ({
+        data: endpoint.getData(json.data),
+      }))
+      .catch(Promise.reject);
   },
 
   getMany: (resource, params) => {
     const endpoint = endpoints(GET_MANY, resource, params);
-    return httpClient(endpoint.url).then(({ json }) => ({
-      data: endpoint.getData(json.data),
-    }));
+    return httpClient(endpoint.url)
+      .then(({ json }) => ({
+        data: endpoint.getData(json.data),
+      }))
+      .catch(Promise.reject);
   },
 
   getManyReference: (resource, params) => {
     const endpoint = endpoints(GET_MANY_REFERENCE, resource, params);
-    return httpClient(endpoint.url).then(({ json }) => ({
-      data: endpoint.getData(json.data, endpoint.target, endpoint.targetId),
-      total: json.data.pageInfo.totalRecord,
-    }));
+    return httpClient(endpoint.url)
+      .then(({ json }) => ({
+        data: endpoint.getData(json.data, endpoint.target, endpoint.targetId),
+        total: json.data.pageInfo.totalRecord,
+      }))
+      .catch(Promise.reject);
   },
 
   update: (resource, params) => {
@@ -76,18 +82,22 @@ export default {
     return httpClient(endpoint.url, {
       method: "POST",
       body: JSON.stringify(params.data),
-    }).then(({ json }) => ({
-      data: endpoint.getData(json.data),
-    }));
+    })
+      .then(({ json }) => ({
+        data: endpoint.getData(json.data),
+      }))
+      .catch(Promise.reject);
   },
 
   delete: (resource, params) => {
     const endpoint = endpoints(DELETE, resource, params);
     httpClient(endpoint.url, {
       method: "DELETE",
-    }).then(({ json }) => ({
-      data: endpoint.getData(json.data),
-    }));
+    })
+      .then(({ json }) => ({
+        data: endpoint.getData(json.data),
+      }))
+      .catch(Promise.reject);
   },
 
   deleteMany: (resource, params) => {
@@ -99,6 +109,8 @@ export default {
           method: "DELETE",
         }).then(({ json }) => result.push(endpoint.getData(json.data)))
       )
-    ).then(() => ({ data: result }));
+    )
+      .then(() => ({ data: result }))
+      .catch(Promise.reject);
   },
 };

--- a/src/services/data-provider.js
+++ b/src/services/data-provider.js
@@ -38,30 +38,26 @@ export default {
 
   getOne: (resource, params) => {
     const endpoint = endpoints(GET_ONE, resource, params);
-    return httpClient(endpoint.url)
-      .then(({ json }) => ({
-        data: endpoint.getData(json.data),
-      }))
-      .catch(Promise.reject);
+    return httpClient(endpoint.url).then(({ json }) => ({
+      data: endpoint.getData(json.data),
+    }));
   },
 
   getMany: (resource, params) => {
     const endpoint = endpoints(GET_MANY, resource, params);
-    return httpClient(endpoint.url)
-      .then(({ json }) => ({
-        data: endpoint.getData(json.data),
-      }))
-      .catch(Promise.reject);
+    return httpClient(endpoint.url).then(({ json }) => ({
+      data: endpoint.getData(json.data),
+    }));
   },
 
   getManyReference: (resource, params) => {
     const endpoint = endpoints(GET_MANY_REFERENCE, resource, params);
-    return httpClient(endpoint.url)
-      .then(({ json }) => ({
-        data: endpoint.getData(json.data, endpoint.target, endpoint.targetId),
-        total: json.data.pageInfo.totalRecord,
-      }))
-      .catch(Promise.reject);
+    return httpClient(endpoint.url).then(({ json }) => ({
+      data: endpoint.getData(json.data, endpoint.target, endpoint.targetId),
+      total: json.data.pageInfo
+        ? json.data.pageInfo.totalRecord
+        : json.data.length,
+    }));
   },
 
   update: (resource, params) => {
@@ -82,22 +78,18 @@ export default {
     return httpClient(endpoint.url, {
       method: "POST",
       body: JSON.stringify(params.data),
-    })
-      .then(({ json }) => ({
-        data: endpoint.getData(json.data),
-      }))
-      .catch(Promise.reject);
+    }).then(({ json }) => ({
+      data: endpoint.getData(json.data),
+    }));
   },
 
   delete: (resource, params) => {
     const endpoint = endpoints(DELETE, resource, params);
     httpClient(endpoint.url, {
       method: "DELETE",
-    })
-      .then(({ json }) => ({
-        data: endpoint.getData(json.data),
-      }))
-      .catch(Promise.reject);
+    }).then(({ json }) => ({
+      data: endpoint.getData(json.data),
+    }));
   },
 
   deleteMany: (resource, params) => {
@@ -109,8 +101,6 @@ export default {
           method: "DELETE",
         }).then(({ json }) => result.push(endpoint.getData(json.data)))
       )
-    )
-      .then(() => ({ data: result }))
-      .catch(Promise.reject);
+    ).then(() => ({ data: result }));
   },
 };

--- a/src/services/data-provider.js
+++ b/src/services/data-provider.js
@@ -85,7 +85,7 @@ export default {
 
   delete: (resource, params) => {
     const endpoint = endpoints(DELETE, resource, params);
-    httpClient(endpoint.url, {
+    return httpClient(endpoint.url, {
       method: "DELETE",
     }).then(({ json }) => ({
       data: endpoint.getData(json.data),

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -2,9 +2,6 @@ import { createMuiTheme } from "@material-ui/core/styles";
 
 const theme = createMuiTheme({
   palette: {
-    primary: {
-      main: "#FFFFFF",
-    },
     secondary: {
       main: "#2339FF",
     },

--- a/src/utils/data/plans-data.js
+++ b/src/utils/data/plans-data.js
@@ -1,0 +1,21 @@
+const getPlansData = (data, target, id) => {
+  let mappedData = data;
+
+  if (Array.isArray(data) && data[0].planId) {
+    mappedData = data.map(mapPlanIdToId);
+  } else if (data.planId) {
+    mappedData = mapPlanIdToId(data);
+  }
+
+  if (target && id) {
+    mappedData = mappedData.filter((item) => item[target] === id);
+  }
+
+  return mappedData;
+};
+
+const mapPlanIdToId = (plan) => {
+  return { id: plan.planId, ...plan };
+};
+
+export default getPlansData;

--- a/src/utils/endpoints/index.js
+++ b/src/utils/endpoints/index.js
@@ -2,6 +2,7 @@ import adminEndpoints from "./admin-endpoints";
 import settingsEndpoints from "./settings-endpoints";
 import organizationsEndpoints from "./organizations-endpoints";
 import applicationEndpoints from "./application-endpoints";
+import plansEndpoints from "./plans-endpoints";
 
 export default (type, resource, params) => {
   switch (resource) {
@@ -13,6 +14,8 @@ export default (type, resource, params) => {
       return organizationsEndpoints(type, params);
     case "Applications":
       return applicationEndpoints(type, params);
+    case "Plans":
+      return plansEndpoints(type, params);
     default:
       return "";
   }

--- a/src/utils/endpoints/plans-endpoints.js
+++ b/src/utils/endpoints/plans-endpoints.js
@@ -1,0 +1,47 @@
+import getData from "../../utils/data/plans-data";
+import {
+  GET_ONE,
+  GET_LIST,
+  GET_MANY,
+  GET_MANY_REFERENCE,
+  CREATE,
+  DELETE,
+} from "react-admin";
+
+const apiUrl = "https://comments-microservice.herokuapp.com/v1";
+
+export default (type, params) => {
+  switch (type) {
+    case GET_MANY:
+    case GET_LIST:
+      return {
+        url: `${apiUrl}/msadmins/plans`,
+        getData: getData,
+      };
+    case GET_MANY_REFERENCE:
+      return {
+        url: `${apiUrl}/msadmins/plans`,
+        getData: (data) => {
+          return getData(data, params.target, params.id);
+        },
+      };
+    case CREATE:
+      return {
+        url: `${apiUrl}/msadmins/plans`,
+        options: {
+          body: JSON.stringify(params.data),
+        },
+        getData: getData,
+      };
+    case GET_ONE:
+    case DELETE:
+      return {
+        url: `${apiUrl}/msadmins/plans/${params.id}`,
+        getData: getData,
+      };
+    default:
+      throw new Error(
+        `Unsupported Application Data Provider request type ${type}`
+      );
+  }
+};

--- a/src/utils/endpoints/plans-endpoints.js
+++ b/src/utils/endpoints/plans-endpoints.js
@@ -6,6 +6,7 @@ import {
   GET_MANY_REFERENCE,
   CREATE,
   DELETE,
+  DELETE_MANY,
 } from "react-admin";
 
 const apiUrl = "https://comments-microservice.herokuapp.com/v1";
@@ -37,6 +38,11 @@ export default (type, params) => {
     case DELETE:
       return {
         url: `${apiUrl}/msadmins/plans/${params.id}`,
+        getData: getData,
+      };
+    case DELETE_MANY:
+      return {
+        urls: params.ids.map((id) => `${apiUrl}/msadmins/plans/${id}`),
         getData: getData,
       };
     default:


### PR DESCRIPTION
This PR implements the plans page.

The page consists of the following components:

- PlanCreate (to create a new plan)
- PlanList (to view the list of plans)
- PlanShow (to view one plan)

The data provider was also updated with the endpoints implementation for the plans API endpoints.

In addition:

Admin was updated to improve certain features.