### PR TITLE
feat: remove ids and show organization email

### DIFF
--- a/src/components/applications/ApplicationList.js
+++ b/src/components/applications/ApplicationList.js
@@ -27,13 +27,10 @@ const ApplicationList = (props) => {
         <SimpleList
           linkType="show"
           primaryText={(record) => record.applicationName}
-          secondaryText={(record) => record.orgId}
-          tertiaryText={(record) => record.organizationName}
         />
       ) : (
         <Datagrid rowClick="show">
           <TextField label="Name" source="applicationName" />
-          <TextField label="ID" source="id" />
           <ReferenceField
             link="show"
             label="Organization"

--- a/src/components/applications/ApplicationShow.js
+++ b/src/components/applications/ApplicationShow.js
@@ -17,7 +17,6 @@ const ApplicationShowActions = ({ basePath, data, resource }) => (
 const ApplicationShow = (props) => (
   <Show label="Show" title="" actions={<ApplicationShowActions />} {...props}>
     <SimpleShowLayout>
-      <TextField source="id" />
       <TextField label="Name" source="applicationName" />
       <TextField label="Organization ID" source="orgId" />
       <ReferenceField
@@ -26,7 +25,7 @@ const ApplicationShow = (props) => (
         source="orgId"
         reference="Organizations"
       >
-        <TextField source="organizationName" />
+        <TextField label="Organization Name" source="organizationName" />
       </ReferenceField>
     </SimpleShowLayout>
   </Show>

--- a/src/components/msadmins/AdminEdit.js
+++ b/src/components/msadmins/AdminEdit.js
@@ -10,7 +10,6 @@ const CustomToolbar = (props) => (
 const AdminEdit = (props) => (
   <Edit {...props}>
     <SimpleForm toolbar={<CustomToolbar />}>
-      <TextInput disabled source="id" />
       <TextInput label="Full Name" source="fullname" />
       <TextInput disabled source="email" />
       <TextInput disabled source="role" />

--- a/src/components/msadmins/AdminList.js
+++ b/src/components/msadmins/AdminList.js
@@ -38,7 +38,6 @@ const AdminList = (props) => {
       ) : (
         <Datagrid rowClick="show" isRowSelectable={(record) => false}>
           <TextField label="Name" source="fullname" />
-          <TextField label="ID" source="id" />
           <EmailField source="email" />
           <TextField source="role" />
         </Datagrid>

--- a/src/components/msadmins/AdminShow.js
+++ b/src/components/msadmins/AdminShow.js
@@ -18,7 +18,7 @@ const AdminShowActions = ({ basePath, data, resource }) => (
 const AdminShow = (props) => (
   <Show label="Show" title="" actions={<AdminShowActions />} {...props}>
     <SimpleShowLayout>
-      <TextField label="Full Name" source="fullname" />
+      <TextField label="Name" source="fullname" />
       <TextField source="email" />
       <TextField source="password" />
       <TextField source="role" />

--- a/src/components/organizations/OrganizationList.js
+++ b/src/components/organizations/OrganizationList.js
@@ -20,12 +20,12 @@ const OrganizationList = (props) => {
         <SimpleList
           linkType="show"
           primaryText={(record) => record.organizationName}
-          secondaryText={(record) => `${record.organizationId}`}
+          secondaryText={(record) => `${record.organizationEmail}`}
         />
       ) : (
         <Datagrid rowClick="show">
           <TextField label="Name" source="organizationName" />
-          <TextField label="ID" source="id" />
+          <TextField label="Email" source="organizationEmail" />
         </Datagrid>
       )}
     </List>

--- a/src/components/organizations/OrganizationList.js
+++ b/src/components/organizations/OrganizationList.js
@@ -1,6 +1,13 @@
 import React from "react";
 import { useMediaQuery } from "@material-ui/core";
-import { List, Datagrid, TextField, SimpleList, Pagination } from "react-admin";
+import {
+  List,
+  Datagrid,
+  TextField,
+  EmailField,
+  SimpleList,
+  Pagination,
+} from "react-admin";
 
 const OrganizationPagination = (props) => (
   <Pagination rowsPerPageOptions={[10, 25, 50]} {...props} />
@@ -25,7 +32,7 @@ const OrganizationList = (props) => {
       ) : (
         <Datagrid rowClick="show">
           <TextField label="Name" source="organizationName" />
-          <TextField label="Email" source="organizationEmail" />
+          <EmailField label="Email" source="organizationEmail" />
         </Datagrid>
       )}
     </List>

--- a/src/components/organizations/OrganizationShow.js
+++ b/src/components/organizations/OrganizationShow.js
@@ -5,6 +5,7 @@ import {
   TabbedShowLayout,
   Tab,
   TextField,
+  EmailField,
   ReferenceManyField,
   SimpleList,
   TopToolbar,
@@ -31,7 +32,7 @@ const OrganizationShow = (props) => {
       <TabbedShowLayout>
         <Tab label="details">
           <TextField label="Name" source="organizationName" />
-          <TextField label="Email" source="organizationEmail" />
+          <EmailField label="Email" source="organizationEmail" />
         </Tab>
         <Tab label="applications">
           <ReferenceManyField

--- a/src/components/organizations/OrganizationShow.js
+++ b/src/components/organizations/OrganizationShow.js
@@ -30,8 +30,8 @@ const OrganizationShow = (props) => {
     <Show label="Show" actions={<OrganizationShowActions />} {...props}>
       <TabbedShowLayout>
         <Tab label="details">
-          <TextField label="Organization Name" source="organizationName" />
-          <TextField label="ID" source="organizationId" />
+          <TextField label="Name" source="organizationName" />
+          <TextField label="Email" source="organizationEmail" />
         </Tab>
         <Tab label="applications">
           <ReferenceManyField

--- a/src/components/plans/PlanList.js
+++ b/src/components/plans/PlanList.js
@@ -33,7 +33,6 @@ const PlanList = (props) => {
       ) : (
         <Datagrid rowClick="show">
           <TextField label="Name" source="planName" />
-          <TextField label="ID" source="id" />
         </Datagrid>
       )}
     </List>

--- a/src/components/plans/PlanShow.js
+++ b/src/components/plans/PlanShow.js
@@ -21,7 +21,6 @@ const PlanShow = (props) => {
       <TabbedShowLayout>
         <Tab label="details">
           <TextField label="Name" source="planName" />
-          <TextField label="ID" source="id" />
         </Tab>
         <Tab label="logging">
           <BooleanField


### PR DESCRIPTION
**What does this PR do?**

The IDs are being removed from the UI as they serve no real purpose to the user and the organization email should be shown under each organization.

**description of Task to be completed?**

- [x] Remove ID fields and inputs from UI
- [x] Add organization email field in organization page.

**How should this be manually tested?**

- In your terminal, run `npm start`.
- On your browser view the pages.

**Any background context you want to provide?**

None

**Questions:**

None
